### PR TITLE
network_predict

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Requirements
 
-For proper codebase please use fork of [darknet](https://github.com/AlexeyAB/darknet). Latest commit I've tested [here](https://github.com/AlexeyAB/darknet/commit/08bc0c9373158da6c42f11b1359ca2c017cef1b5)
+For proper codebase please use fork of [darknet](https://github.com/AlexeyAB/darknet). Latest commit I've tested [here](https://github.com/AlexeyAB/darknet/commit/9dc897d2c77d5ef43a6b237b717437375765b527)
 
 In order to use go-darknet, `libdarknet.so` should be available in one of
 the following locations:

--- a/network.c
+++ b/network.c
@@ -14,7 +14,7 @@ struct network_box_result perform_network_detect(network *n, image *img, int cla
         sized = resize_image(*img, n->w, n->h);
     }
     struct network_box_result result = { NULL };
-    network_predict_ptr(n, sized.data);
+    network_predict(*n, sized.data);
     int nboxes = 0;
     result.detections = get_network_boxes(n, img->w, img->h, thresh, hier_thresh, 0, 1, &result.detections_len, letter_box);
     if (nms) {


### PR DESCRIPTION
Thanks to [sam-cts](https://github.com/sam-cts) for issue https://github.com/LdDl/go-darknet/issues/8.

Updated method of passing arguments to prediction C-function.
